### PR TITLE
Refocus and correctly report all discrepancies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .precomp/
 /Git-Status-*
 /releases/
+git-status.pdf
+git-status.ps

--- a/Changes
+++ b/Changes
@@ -1,6 +1,18 @@
 Revision history for Git-Status
 
 {{$NEXT}}
+    - Updated to notifify of all seven non-blank Git status codes indicating
+      a "dirty" repository (i.e., anything that would throw an exception
+      with App::Mi6)
+    - Numbered all instances and showed codes 1-7 in the order shown in the
+      git-status man page to help ensure complete coverage
+    - Removed the incorrect "New" code added in the last version
+    - Added more README notes about the latest handling of git-status with
+      reference to Git documentation
+    - Added /xt testing
+    - Added two .gitignore entries for git-status man page PS and PDF generation
+    - Added a test dependency: File::Temp
+    - Added method 'is-clean' as a simple summary check
 
 0.0.2  2024-06-19T10:57:07+02:00
     - Added support for new and renamed files, courtesy of

--- a/META6.json
+++ b/META6.json
@@ -21,6 +21,7 @@
     "GIT"
   ],
   "test-depends": [
+    "File::Temp"
   ],
   "version": "0.0.2"
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ use Git::Status;
 
 my $status := Git::Status.new(:$directory);
 
+if $status.is-clean {
+    say "Is clean";
+}
+
+if $status.modified -> @modified {
+    say "Modified:";
+    .say for @modified;
+}
+
 if $status.added -> @added {
     say "Added:";
     .say for @added;
@@ -23,19 +32,19 @@ if $status.deleted -> @deleted {
     .say for @deleted;
 }
 
-if $status.modified -> @modified {
-    say "Modified:";
-    .say for @modified;
-}
-
-if $status.newfile -> @newfile {
-    say "Newfile:";
-    .say for @newfile;
-}
-
 if $status.renamed -> @renamed {
     say "Renamed:";
     .say for @renamed;
+}
+
+if $status.copied -> @copied {
+    say "Copied:";
+    .say for @copied;
+}
+
+if $status.updated -> @updated {
+    say "Updated:";
+    .say for @updateded;
 }
 
 if $status.untracked -> @untracked {
@@ -47,7 +56,9 @@ if $status.untracked -> @untracked {
 DESCRIPTION
 ===========
 
-Git::Status provides a simple way to obtain the status of a git repository.
+Git::Status provides a simple way to obtain the status of a git repository using the `git status --porcelain` command (version 1) and simplifying the results to indicate whether the repository is 'clean' or 'dirty'. This module's primary purpose is to determine whether any action is required to satisfy further use by `App::Mi6` or to indicate user intervention is necessary.
+
+Note the full output of `git status --porcelain` is quite complex and completely identifies the situation with regards to both the index and the working tree (a complex task with many possible combinations). See the `git-status` man page for details.
 
 PARAMETERS
 ==========
@@ -59,6 +70,16 @@ The directory of the git repository. Can be specified as either an `IO::Path` ob
 
 METHODS
 =======
+
+is-clean
+--------
+
+Returns the value of the $!clean variable which is True for a "clean" Git directory.
+
+gist
+----
+
+A text representation of the object, empty string if there were no modified, added, deleted, renamed, copied, updated, or untracked files.
 
 added
 -----
@@ -74,11 +95,6 @@ directory
 ---------
 
 The directory of the repository, as an `IO::Path` object.
-
-gist
-----
-
-A text representation of the object, empty string if there were no added, deleted or modified files.
 
 modified
 --------

--- a/lib/Git/Status.rakumod
+++ b/lib/Git/Status.rakumod
@@ -9,9 +9,48 @@ has str  @.renamed   is built(False);
 
 method TWEAK() {
     indir $!directory, {
+        # By default, the git command is using version 1 format:
+        # XY PATH
+        # XY ORIG_PATH -> PATH
+
         my $proc := run <git status --porcelain>, :out;
         for $proc.out.lines {
+            my %h; # the two XY chars which may be the same. 
+                   # spaces are ignored
             my $path := .substr(3);
+            my @c = $_.comb[0..1];
+            for @c {
+                next if $_ eq ' ';
+                %h{$_} = 1;
+            }
+            for %h.keys {
+                # there are 10 known non-space characters
+                when $_ eq 'M' {
+                    # Modified  
+                }
+                when $_ eq 'A' {
+                    # Added
+                }
+                when $_ eq 'D' {
+                    # Deleted
+                }
+                when $_ eq 'R' {
+                    # Renamed
+                }
+                when $_ eq 'C' {
+                    # Copied
+                }
+                when $_ eq 'U' {
+                    # Updated, but Unmerged
+                }
+                when $_ eq '?' {
+                    # Untracked path
+                }
+                when $_ eq '!' {
+                    # Ignored path
+                }
+            }
+
             if .starts-with('?? ') {
                 @!untracked.push: $path;
             }

--- a/lib/Git/Status.rakumod
+++ b/lib/Git/Status.rakumod
@@ -5,7 +5,6 @@ has str  @.added     is built(False);
 has str  @.deleted   is built(False);
 has str  @.modified  is built(False);
 has str  @.untracked is built(False);
-has str  @.newfile   is built(False);
 has str  @.renamed   is built(False);
 
 method TWEAK() {
@@ -26,10 +25,7 @@ method TWEAK() {
             elsif .starts-with('A') {
                 @!added.push($path);
             }
-            elsif .substr-eq('N', 1) {
-                @!newfile.push: $path;
-            }
-            elsif .substr-eq('R', 1) {
+            elsif .starts-with('R') {
                 @!renamed.push: $path;
             }
             else {

--- a/xt/1-live-test.rakutest
+++ b/xt/1-live-test.rakutest
@@ -1,0 +1,29 @@
+use Test;
+
+use File::Temp;
+
+use Git::Status;
+
+my $tmpdir = tempdir;
+my $dir    = $*CWD;
+
+chdir $tmpdir;
+run <git init --quiet>;
+# add a file
+my $f = "text.txt"; 
+spurt $f, "some text";
+is $f.IO.r, True, "\$f is a valid file";
+
+run <<git add $f>>;
+
+chdir $dir;
+my $status = Git::Status.new: :directory($tmpdir);
+
+
+is "$tmpdir/.git".IO.d, True, "is a git dir";
+is "$tmpdir/$f".IO.f, True, "is a file";
+
+is $status.clean, False, "dirty git repo";
+
+done-testing;
+


### PR DESCRIPTION
See the Changes file for details.

This PR attempts to focus the use of the module on ensuring its target Git directory is “clean” so that it is usable by App::Mi6 without error. If the target is “dirty” (not clean), then it will show the details so that corrective actions can be taken.

This PR also satisfies issue #4.