### PR TITLE
Fix zef install error holdover from version 0.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,5 @@ jobs:
           zef install --/test --deps-only .
       - name: Run Tests
         run: raku run-tests
+      - name: Install Module
         run: zef --debug install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,5 +24,9 @@ jobs:
       - uses: Raku/setup-raku@v1
         with:
           raku-version: ${{ matrix.raku-version }}
+      - name: Install Dependencies
+        run: |
+          zef install --/test --deps-only .
       - name: Run Tests
         run: raku run-tests
+        run: zef --debug install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,8 @@ jobs:
         with:
           raku-version: ${{ matrix.raku-version }}
       - name: Install Dependencies
-        run: |
-          zef install --/test --deps-only .
-      - name: Run Tests
+        run:  zef install --/test --deps-only .
+      - name: Run Special Tests
         run: raku run-tests
       - name: Install Module
         run: zef --debug install .

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Git-Status
 
 {{$NEXT}}
+    - Fixed git error with zef install by comparing lists of subdirectories
+    - Added an addional /xt test
 
 0.0.3  2024-06-23T13:45:23+02:00
     - Updated to notifify of all seven non-blank Git status codes indicating

--- a/META6.json
+++ b/META6.json
@@ -21,6 +21,7 @@
     "GIT"
   ],
   "test-depends": [
+    "File::Find",
     "File::Temp"
   ],
   "version": "0.0.3"

--- a/META6.json
+++ b/META6.json
@@ -6,6 +6,7 @@
   "build-depends": [
   ],
   "depends": [
+    "File::Find"
   ],
   "description": "obtain status of a git repository",
   "license": "Artistic-2.0",
@@ -21,7 +22,6 @@
     "GIT"
   ],
   "test-depends": [
-    "File::Find",
     "File::Temp"
   ],
   "version": "0.0.3"

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -1,11 +1,17 @@
 use Test;
 use Git::Status;
 
+use File::Find;
+
 plan 2;
 
 my $status := Git::Status.new;
 isa-ok $status, Git::Status;
 
-is-deeply $status.directory, $*CWD, 'directory ok';
+my (@dirs1, @dirs2);
+@dirs1 = find :dir($*CWD),             :type<dir>, :recursive(False);
+@dirs2 = find :dir($status.directory), :type<dir>, :recursive(False);
+
+is-deeply @dirs1, @dirs2, 'directory ok';
 
 # vim: expandtab shiftwidth=4

--- a/xt/1-live-test.rakutest
+++ b/xt/1-live-test.rakutest
@@ -4,26 +4,28 @@ use File::Temp;
 
 use Git::Status;
 
+plan 5;
+
 my $tmpdir = tempdir;
 my $dir    = $*CWD;
 
 chdir $tmpdir;
 run <git init --quiet>;
 # add a file
-my $f = "text.txt"; 
+my $f = "text.txt";
 spurt $f, "some text";
 is $f.IO.r, True, "\$f is a valid file";
-
 run <<git add $f>>;
 
 chdir $dir;
 my $status = Git::Status.new: :directory($tmpdir);
-
-
 is "$tmpdir/.git".IO.d, True, "is a git dir";
 is "$tmpdir/$f".IO.f, True, "is a file";
-
 is $status.clean, False, "dirty git repo";
 
-done-testing;
-
+# commit and test again
+chdir $tmpdir;
+run <git commit -a -m'clean'>;
+chdir $dir;
+$status = Git::Status.new: :directory($tmpdir);
+is $status.clean, True, "clean git repo";


### PR DESCRIPTION
See the Changes file for details.

Also added File::temp as a test dependency.

The fix was to use the is-deeply test on sub-directories of the two top-level collections rather than from the top-level directly.

This should fix issue #9.